### PR TITLE
adds coverage reporting using nyc and coveralls.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+coverage
+nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ node_js:
   - 'iojs'
   - '0.12'
   - '0.10'
+after_success: npm run coveralls

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   },
   "scripts": {
     "test": "mocha",
-    "bench": "matcha benchmark.js"
+    "bench": "matcha benchmark.js",
+    "coverage": "nyc npm test && nyc report",
+    "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
   },
   "files": [
     "index.js"
@@ -47,8 +49,10 @@
     "supports-color": "^1.3.0"
   },
   "devDependencies": {
+    "coveralls": "^2.11.2",
     "matcha": "^0.6.0",
     "mocha": "*",
+    "nyc": "^2.1.4",
     "require-uncached": "^1.0.2",
     "resolve-from": "^1.0.0",
     "semver": "^4.3.3"

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,8 @@
 > Terminal string styling done right
 
 [![Build Status](https://travis-ci.org/sindresorhus/chalk.svg?branch=master)](https://travis-ci.org/sindresorhus/chalk) [![](http://img.shields.io/badge/unicorn-approved-ff69b4.svg)](https://www.youtube.com/watch?v=9auOCbH5Ns4)
+[![Coverage Status](https://coveralls.io/repos/sindresorhus/chalk/badge.svg?branch=)](https://coveralls.io/r/sindresorhus/chalk?branch=)
+
 
 [colors.js](https://github.com/Marak/colors.js) used to be the most popular string styling module, but it has serious deficiencies like extending `String.prototype` which causes all kinds of [problems](https://github.com/yeoman/yo/issues/68). Although there are other ones, they either do too much or not enough.
 


### PR DESCRIPTION
This pull adds coverage reporting, using coveralls.io and the [nyc](https://www.npmjs.com/package/nyc) instrumenter.

* run `npm run coverage` to get a human readable coverage report.
* run `npm run coverage -- --reporter=lcov` to get an HTML report over coverage in the /coverage folder.
* run `npm run coveralls` to report coverage to the [coveralls.io](https://coveralls.io/).
  * you'll need to setup your repo on coveralls.io and grap the `COVERALLS_REPO_TOKEN`.
  * on travis-ci.org, you'll need to set an environment variable with the value of `COVERALLS_REPO_TOKEN `

```shell
---------------|-----------|-----------|-----------|-----------|
File           |   % Stmts |% Branches |   % Funcs |   % Lines |
---------------|-----------|-----------|-----------|-----------|
   ./          |     98.08 |     77.78 |     90.91 |     98.08 |
      index.js |     98.08 |     77.78 |     90.91 |     98.08 |
---------------|-----------|-----------|-----------|-----------|
All files      |     98.08 |     77.78 |     90.91 |     98.08 |
---------------|-----------|-----------|-----------|-----------|
```